### PR TITLE
Add production.cloudfront.docker.com to allowed-endpoints

### DIFF
--- a/.github/workflows/age.yml
+++ b/.github/workflows/age.yml
@@ -44,6 +44,7 @@ jobs:
             gitlab.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.gitlab.com:443

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -42,6 +42,7 @@ jobs:
             gitlab.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.gitlab.com:443

--- a/.github/workflows/cryptolyzer.yml
+++ b/.github/workflows/cryptolyzer.yml
@@ -50,6 +50,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             ports.ubuntu.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/open-interpreter.yml
+++ b/.github/workflows/open-interpreter.yml
@@ -50,6 +50,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             ports.ubuntu.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -50,6 +50,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             ports.ubuntu.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/sslyze.yml
+++ b/.github/workflows/sslyze.yml
@@ -47,6 +47,7 @@ jobs:
             github.com:443
             ports.ubuntu.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/visidata.yml
+++ b/.github/workflows/visidata.yml
@@ -50,6 +50,7 @@ jobs:
             github.com:443
             ports.ubuntu.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443


### PR DESCRIPTION
Added `production.cloudfront.docker.com:443` to the `allowed-endpoints` list for `harden-runner` in the following workflow files:
- `.github/workflows/age.yml`
- `.github/workflows/awscli.yml`
- `.github/workflows/cryptolyzer.yml`
- `.github/workflows/open-interpreter.yml`
- `.github/workflows/ruff.yml`
- `.github/workflows/sslyze.yml`
- `.github/workflows/visidata.yml`

The endpoint was added in alphabetical order. YAML syntax was verified for all modified files.

Fixes #8838

---
*PR created automatically by Jules for task [4444726349235535297](https://jules.google.com/task/4444726349235535297) started by @jauderho*